### PR TITLE
added new SoftBreak inline element from pandoc 1.16

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -37,6 +37,7 @@ our %ELEMENTS = (
     Cite        => [ Inline => qw(citations content) ],
     Code        => [ Inline => qw(attr content) ],
     Space       => ['Inline'],
+    SoftBreak   => ['Inline'],
     LineBreak   => ['Inline'],
     Math        => [ Inline => qw(type content) ],
     RawInline   => [ Inline => qw(format content) ],


### PR DESCRIPTION
I totally overlooked the new SoftBreak element from pandoc 1.16 but luckily I ran into it the other day.