### PR TITLE
specific TO_JSON methods to ensure right scalar types

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -68,12 +68,42 @@ foreach (
 
 use Carp;
 use JSON qw(decode_json);
-use Scalar::Util qw(reftype);
+use Scalar::Util qw(blessed reftype);
 use Pandoc::Walker qw(walk);
 
 use parent 'Exporter';
 our @EXPORT = ( keys %ELEMENTS, qw(Document attributes citation pandoc_json) );
 our @EXPORT_OK = ( @EXPORT, 'element' );
+
+# This code ref has file scope so is visible from all inner packages
+my $normalize_ast = sub {
+    # There is no easy way in Perl to tell if a scalar value is already a string or number,
+    # so we stringify all scalar values and numify/boolify as needed afterwards.
+    my($ast, $normalize_ast) = @_;
+    if ( blessed $ast ) {
+        return $ast if $ast->can('TO_JSON'); # JSON.pm will convert
+        # may have overloaded stringification! Should we check?
+        # require overload;
+        # return "$ast" if overload::Method($ast, q/""/) or overload::Method($ast, q/0+/);
+        # carp "Non-stringifiable object $ast";
+        return "$ast";  
+    }
+    elsif ( 'ARRAY' eq ref $ast ) {
+        return [  
+            map { 
+                ref($_) ? $normalize_ast->($_, $normalize_ast) : "$_";
+            } @$ast 
+        ];
+    }
+    elsif ( 'HASH' eq ref $ast ) {
+        my %ret = %$ast;
+        while ( my($k, $v) = each %ret ) {
+            $ret{$k} = ref($v) ? $normalize_ast->($v, $normalize_ast) : "$v";
+        }
+        return \%ret;
+    }
+    else { return "$ast" }
+};
 
 # create constructor functions
 foreach my $name ( keys %ELEMENTS ) {
@@ -204,7 +234,8 @@ sub pandoc_json($) {
     use strict;
     our $VERSION = '0.04';
     our @ISA     = ('Pandoc::Document::Element');
-    sub TO_JSON     { [ @{ $_[0] } ] }
+    sub TO_JSON     { $normalize_ast->( [ @{ $_[0] } ], $normalize_ast ) }
+    # sub TO_JSON     { [ @{ $_[0] } ] }
     sub name        { 'Document' }
     sub meta        { $_[0]->[0]->{unMeta} }
     sub content     { $_[0]->[1] }
@@ -224,7 +255,7 @@ sub pandoc_json($) {
     sub to_json {
         JSON->new->utf8->convert_blessed->encode( $_[0] );
     }
-    sub TO_JSON { return { %{ $_[0] } } }
+    # sub TO_JSON { return { %{ $_[0] } } }
     sub name    { $_[0]->{t} }
     sub content { $_[0]->{c} }
     sub is_document { 0 }
@@ -235,6 +266,12 @@ sub pandoc_json($) {
     *query     = *Pandoc::Walker::query;
     *transform = *Pandoc::Walker::transform;
 
+    sub TO_JSON {
+        # Run everything thru normalize_ast so arrays/hashes are cloned
+        # and objects without TO_JSON methods are stringified.
+        return $normalize_ast->( { %{ $_[0] } }, $normalize_ast );
+    }
+    
     sub new_from_ast { bless $_[1] => $_[0] }
 
     sub string {
@@ -363,8 +400,7 @@ sub pandoc_json($) {
     }
 
     sub TO_JSON {
-        my ( $self ) = @_;
-        my $ast = {%$self};
+        my $ast = $normalize_ast->( {%{$_[0]}}, $normalize_ast );
         if (    $Pandoc::Elements::PANDOC_VERSION
             and ($Pandoc::Elements::PANDOC_VERSION lt '1.16') )
         {
@@ -374,6 +410,47 @@ sub pandoc_json($) {
         return $ast;
     }
 
+}
+
+# Special TO_JSON methods to coerce data to int/number/Boolean as appropriate
+
+sub Pandoc::Document::Header::TO_JSON {
+    my $data = $normalize_ast->( { %{ $_[0] } }, $normalize_ast );
+    # coerce heading level to int
+    $data->{c}[0] = int( $data->{c}[0] );
+    return $data;
+}
+
+sub Pandoc::Document::OrderedList::TO_JSON {
+    my $data = $normalize_ast->( { %{ $_[0] } }, $normalize_ast );
+    # coerce first item number to int
+    $data->{c}[0][0] = int( $data->{c}[0][0] );
+    return $data;
+}
+
+sub Pandoc::Document::Table::TO_JSON {
+    my $data = $normalize_ast->( { %{ $_[0] } }, $normalize_ast );
+    # coerce column widths to numbers (floats)
+    $_ += 0 for @{ $data->{c}[2] }; # faster than map
+    return $data;
+}
+
+sub Pandoc::Document::MetaBool::TO_JSON {
+    my $data = { %{ $_[0] } };
+    # coerce Bool value to JSON Boolean object
+    $data->{c} = $data->{c} ? JSON::true() : JSON::false();
+    return $data;
+}
+
+sub Pandoc::Document::Cite::TO_JSON {
+    my $data = $normalize_ast->( { %{ $_[0] } }, $normalize_ast );
+    for my $citation ( @{ $data->{c}[0] } ) {
+        for my $key ( qw[ citationHash citationNoteNum ] ) {
+            # coerce to int
+            $citation->{$key} = int( $citation->{$key} );
+        }
+    }
+    return $data;
 }
 
 1;

--- a/xt/scalar-types.t
+++ b/xt/scalar-types.t
@@ -1,0 +1,32 @@
+use strict;
+use Test::More;
+use Pandoc::Elements qw(pandoc_json);
+
+# IMPORTANT:
+#
+# The JSON in the __DATA__ section is deliberately erroneous,
+# i.e. pandoc should choke on it unless the appropriate
+# TO_JSON methods have done their magic on it!
+
+SKIP: {
+    exists $ENV{PANDOC_VERSION} or skip 'pandoc seems to be missing', 2;
+    eval { require IPC::Run3 } or skip 'IPC::Run3 not installed', 2;
+
+    my $json_in = do { local $/; <DATA>; };
+    my $document = eval { pandoc_json( $json_in ) };
+    my $error = $@;
+    is $error, "", 'no error reading "bad" JSON';
+    isa_ok $document, 'Pandoc::Document';
+    my $json = $document->to_json;
+
+    IPC::Run3::run3( [pandoc => -f => 'json', -t => 'markdown'], \$json, \my $stdout, \my $stderr );
+
+    is $stderr, "", 'no errors feeding JSON to pandoc' or note $stderr;
+    note $stdout;
+}
+
+done_testing;
+
+__DATA__
+[{"unMeta":{"MetaBool":{"t":"MetaBool","c":true}}},[{"t":"Header","c":["1",["heading",[],[]],[{"t":"Str","c":"Heading"},{"c":[],"t":"Space"}]]},{"t":"Para","c":[{"c":[[{"citationMode":{"t":"NormalCitation","c":[]},"citationPrefix":[{"c":"citation","t":"Str"}],"citationSuffix":[{"c":[],"t":"Space"},{"c":"p.","t":"Str"},{"c":[],"t":"Space"},{"c":13,"t":"Str"}],"citationId":"author2015","citationNoteNum":"0","citationHash":"0"}],[{"t":"Str","c":"[citation"},{"t":"Space","c":[]},{"c":"@author2015","t":"Str"},{"t":"Space","c":[]},{"c":"p.","t":"Str"},{"c":[],"t":"Space"},{"c":"13]","t":"Str"}]],"t":"Cite"},{"c":",","t":"Str"},{"c":[],"t":"Space"}]},{"t":"OrderedList","c":[["2",{"t":"Decimal","c":[]},{"t":"OneParen","c":[]}],[[{"t":"Plain","c":[{"c":"#1=2","t":"Str"},{"t":"Space","c":[]}]}],[{"c":[{"t":"Str","c":"#2=3"}],"t":"Plain"}]]]},{"t":"Table","c":[[{"t":"Str","c":"Table"},{"t":"Space","c":[]}],[{"t":"AlignLeft","c":[]},{"t":"AlignLeft","c":[]},{"t":"AlignLeft","c":[]}],["0","0","0"],[[{"t":"Plain","c":[{"t":"Str","c":"M."}]}],[{"t":"Plain","c":[{"t":"Str","c":"F."}]}],[{"c":[{"t":"Str","c":"N."}],"t":"Plain"}]],[[[{"c":[{"t":"Str","c":"hic"}],"t":"Plain"}],[{"c":[{"c":"haec","t":"Str"}],"t":"Plain"}],[{"c":[{"c":"hoc","t":"Str"}],"t":"Plain"}]]]]}]]
+


### PR DESCRIPTION
Unlike Perl pandoc cares about whether a given scalar is a string
(including "quoted digits"), an integer or a float. In most
places pandoc expects strings, but there are some places where it
expects integers or floats. This commit modifies/adds TO_JSON
methods to ensure that scalars in all elements are of the right
type. It also ensures that the value of a MetaBool is a
JSON::PP::Boolean object, so that it gets serialized as a JSON Boolean.
It does so without modifying the data in the object to be
serialized. If anything in the object *is* modified that is a
bug. The reason for this is that a user may legitimately have an
object with an appropriate TO_JSON method take the place of a
scalar without that object being flattened just because they call
the (lowercase) to_json method. Also added: an xt test to ensure
that pandoc doesn't choke on the reserialized version of a
document with 'bad' scalars: all should-be numbers replaced by
strings, and all (one) digits-only strings replaced by a number.