### PR TITLE
updates for pandoc 1.18 - no documentation yet

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -293,7 +293,7 @@ sub pandoc_json($) {
         join '', map { $_->string } @{$_[0]->content}
     }
     sub api_version { $_[0]->{'pandoc-api-version'} }
-    sub new_from_ast { shift;  Pandoc::Element::Document( @_ ); }
+    sub new_from_ast { shift;  Pandoc::Document( @_ ); }
 }
 
 {

--- a/t/api-version.t
+++ b/t/api-version.t
@@ -1,0 +1,52 @@
+use strict;
+use Test::More 0.96; # for subtests
+use Pandoc::Elements;
+
+use constant AV => 'Pandoc::Document::ApiVersion';
+
+
+my %objects = (
+    from_array  => new_ok( AV, [ [ 1, 17, 0, 4 ] ], 'new from array'),
+    from_list   => new_ok( AV, [ ( 1, 17, 0, 4 ) ], 'new from list'),
+    from_string => new_ok( AV, ['1.17.0.4'], 'new from string'),
+);
+
+my $standard = bless( [ 1, 17, 0, 4 ], 'Pandoc::Document::ApiVersion' );
+
+for my $name ( sort keys %objects ) {
+    is_deeply $objects{ $name }->TO_JSON, $standard->TO_JSON, "$name structure";
+}
+
+my %compared = (
+    empty  => {
+        object => new_ok( AV, [], 'new empty'),
+        api => "",
+        exe => '1.12',
+    },
+    lesser => {
+        object => new_ok( AV, [ [ 1, 16 ] ], 'new lesser'),
+        api => '1.16',
+    },
+    more => {
+        object => $standard,
+        api => '1.17.0.4',
+        exe => '1.18',
+    }
+);
+
+for my $name ( sort keys %compared ) {
+    ok $compared{$name}{object}->EQ($compared{$name}{api}), "$name API";
+    if ( $compared{$name}{exe} ) {
+        ok $compared{$name}{object}->eq($compared{$name}{exe}), "$name executable";
+    }
+    ok $compared{$name}{object}->LE($standard), "$name LE standard";
+
+    ok $standard->GE($compared{$name}{api}), "standard GE $name";
+    ok $standard->ge($compared{$name}{exe}), "standard ge $name";
+
+    # note explain $compared{$name}{object}; 
+}
+
+is_deeply $standard->TO_JSON, [ 1, 17, 0, 4 ], 'TO_JSON';
+
+done_testing;

--- a/t/ast.t
+++ b/t/ast.t
@@ -12,13 +12,13 @@ ok !$doc->is_block, 'is_block';
 ok !$doc->is_inline, 'is_inline';
 ok !$doc->is_meta, 'is_meta';
 
-my $meta = $doc->[0]->{unMeta};
+my $meta = $doc->{meta};
 is $meta, $doc->meta, '->meta';
 
 ok $meta->{title}->is_meta, 'is_meta';
 is $meta->{title}->name, 'MetaInlines', 'name';
 
-my $para = $doc->[1]->[0];
+my $para = $doc->{blocks}->[0];
 is $para->name, 'Para', 'name';
 is_deeply $para->content, [ Str 'test' ];
 ok $para->is_block, 'is_block';

--- a/t/line-block.t
+++ b/t/line-block.t
@@ -1,0 +1,96 @@
+use strict;
+use Test::More;
+use Pandoc::Elements;
+
+Pandoc::Elements->can('LineBlock') or plan skip_all => 'Pandoc::Elements too old';
+
+my $e = LineBlock [ [ Str "  foo"], [ Str "bar"], [ Str " baz"], ];
+
+my $expected =bless(
+    {   'c' => [
+            [ bless( { 'c' => "  foo", 't' => 'Str' }, 'Pandoc::Document::Str' ) ],
+            [ bless( { 'c' => "bar", 't' => 'Str' }, 'Pandoc::Document::Str' ) ],
+            [ bless( { 'c' => " baz", 't' => 'Str' }, 'Pandoc::Document::Str' ) ]
+        ],
+        't' => 'LineBlock'
+    },
+    'Pandoc::Document::LineBlock'
+);
+
+is_deeply $e, $expected, 'object' or note explain $e;
+
+my %expected = (
+    '0' => {
+        'c' => [
+            { 'c' => "\x{a0}\x{a0}foo", 't' => 'Str' },
+            { 'c' => [],                't' => 'LineBreak' },
+            { 'c' => "bar",             't' => 'Str' },
+            { 'c' => [],                't' => 'LineBreak' },
+            { 'c' => "\x{a0}baz",       't' => 'Str' }
+        ],
+        't' => 'Para'
+    },
+    '1.18' => {
+        'c' => [
+            [ { 'c' => "\x{a0}\x{a0}foo", 't' => 'Str' } ],
+            [ { 'c' => "bar",             't' => 'Str' } ],
+            [ { 'c' => "\x{a0}baz",       't' => 'Str' } ]
+        ],
+        't' => 'LineBlock'
+    },
+);
+
+my %api_versions = (
+    undef          => { api_version => undef, expected => '1.18' },
+    'empty string' => { api_version => "",    expected => '0' },
+    '0'            => { api_version => '0',   expected => '0' },
+    '1.12' => { api_version => pandoc_api_version_of( '1.12' ), expected => '0' },
+    '1.18' => { api_version => pandoc_api_version_of( '1.18' ), expected => '1.18' },
+);
+
+for my $name ( sort keys %api_versions ) {
+    local $Pandoc::Elements::PANDOC_API_VERSION = $api_versions{$name}{api_version};
+    is_deeply $e->TO_JSON, $expected{ $api_versions{$name}{expected} }, "api-version: $name";
+}
+
+{
+
+    # Pandoc::Document::TO_JSON() localizes $Pandoc::Elements::PANDOC_API_VERSION
+    # according to the API version contained in the document, and then
+    # Pandoc::Document::Element::TO_JSON() calls TO_JSON() recursively on
+    # contained objects so that Pandoc::Document::LineBlock::TO_JSON()
+    # picks up the right API version.
+
+    local $Pandoc::Elements::PANDOC_API_VERSION = 0;
+
+    my $doc = Document { 
+        api_version_of => '1.18',
+        meta => {},
+        blocks => [
+            Para [ Str 'foo' ],
+            LineBlock [ [ Str 'baz' ], [ Str 'grault' ], [ Str 'corge' ] ],
+            Para [ Str 'waldo' ],
+        ],
+    };
+
+    is_deeply $doc->TO_JSON, 
+    {   'blocks' => [
+            { 'c' => [ { 'c' => 'foo', 't' => 'Str' } ], 't' => 'Para' },
+            {   'c' => [
+                    [ { 'c' => 'baz',    't' => 'Str' } ],
+                    [ { 'c' => 'grault', 't' => 'Str' } ],
+                    [ { 'c' => 'corge',  't' => 'Str' } ]
+                ],
+                't' => 'LineBlock'
+            },
+            { 'c' => [ { 'c' => 'waldo', 't' => 'Str' } ], 't' => 'Para' }
+        ],
+        'meta'               => {},
+        'pandoc-api-version' => [ 1, 17, 0, 4 ]
+    }, "doc's API version honored";
+
+}
+
+ok 1;
+
+done_testing;

--- a/t/synopsis-noclass.t
+++ b/t/synopsis-noclass.t
@@ -1,0 +1,47 @@
+use strict;
+use Test::More;
+use Pandoc::Elements;
+use JSON;
+
+BEGIN {
+    plan skip_all => 'Test::Deep not available' unless eval 'require Test::Deep; 1;';
+    Test::Deep->import( qw[cmp_deeply noclass] );
+}
+
+my $ast = Document { 
+        title => MetaInlines [ Str 'Greeting' ] 
+    }, [
+        Header( 1, attributes { id => 'de' }, [ Str 'Gruß' ] ),
+        Para [ Str 'hello, world!' ],
+    ], api_version_of => '1.18';
+
+# note explain $ast->TO_JSON;
+
+cmp_deeply $ast, noclass {   'blocks' => [
+        {   'c' => [ 1, [ 'de', [], [] ], [ { 'c' => 'Gruß', 't' => 'Str' } ] ],
+            't' => 'Header'
+        },
+        { 'c' => [ { 'c' => 'hello, world!', 't' => 'Str' } ], 't' => 'Para' }
+    ],
+    'meta' => {
+        'title' =>
+          { 'c' => [ { 'c' => 'Greeting', 't' => 'Str' } ], 't' => 'MetaInlines' }
+    },
+    'pandoc-api-version' => [ 1, 17, 0, 4 ]
+};
+
+my $json = JSON->new->utf8->convert_blessed->encode($ast);
+cmp_deeply decode_json($json), noclass($ast), 'encode/decode JSON';
+cmp_deeply Pandoc::Elements::pandoc_json($json), noclass($ast), 'pandoc_json';
+$json = $ast->to_json;
+cmp_deeply decode_json($json), noclass($ast), 'to_json';
+
+eval { Pandoc::Elements->pandoc_json(".") };
+like $@, qr{.+at.+synopsis.*\.t}, 'error in pandoc_json';
+
+done_testing;
+
+__DATA__
+% Greeting
+# Gruß {.de}
+hello, world!

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,68 +1,17 @@
 use strict;
 use Test::More;
-
 use Pandoc::Elements;
 use JSON;
 
-# TODO: use Test::Deep::noclass() instead? See synopsis-noclass.t!
-#
-# HACK: De-objectify api-version so that tests pass.
-# This is a bug in Test::More::is_deeply(), not in Pandoc::Elements:
-# is_deeply() compares the stringification of overloaded objects,
-# even though it's supposed to compare data structures!
-# Test::Deep offers a non-broken way of doing this and more.
-    
-my $doc = Document { 
+my $ast = Document { 
         title => MetaInlines [ Str 'Greeting' ] 
     }, [
         Header( 1, attributes { id => 'de' }, [ Str 'Gruß' ] ),
         Para [ Str 'hello, world!' ],
-    ],
-    api_version_of => '1.18';
+    ], api_version_of => '1.18';
 
-#<<<
-is_deeply $doc,
-  bless(
-    { 'blocks' => [
-        bless(
-          { 'c' => [
-              1,
-              [ 'de', [], [] ],
-              [ bless( { 'c' => 'Gruß', 't' => 'Str' }, 'Pandoc::Document::Str' ) ]
-            ],
-            't' => 'Header'
-          },
-          'Pandoc::Document::Header'
-        ),
-        bless(
-          { 'c' => [
-              bless( { 'c' => 'hello, world!', 't' => 'Str' }, 'Pandoc::Document::Str' )
-            ],
-            't' => 'Para'
-          },
-          'Pandoc::Document::Para'
-        )
-      ],
-      'meta' => {
-        'title' => bless(
-          { 'c' =>
-              [ bless( { 'c' => 'Greeting', 't' => 'Str' }, 'Pandoc::Document::Str' ) ],
-            't' => 'MetaInlines'
-          },
-          'Pandoc::Document::MetaInlines'
-        )
-      },
-      'pandoc-api-version' => bless( [ 1, 17, 0, 4 ], 'Pandoc::Document::ApiVersion' )
-    },
-    'Pandoc::Document'
-    ),
-  'document';
-#>>>
-
-my $ast = $doc->TO_JSON;
-
-is_deeply $ast,
-  { 'blocks' => [
+is_deeply $ast, { 
+    'blocks' => [
         {   'c' => [ 1, [ 'de', [], [] ], [ { 'c' => 'Gruß', 't' => 'Str' } ] ],
             't' => 'Header'
         },
@@ -73,12 +22,12 @@ is_deeply $ast,
           { 'c' => [ { 'c' => 'Greeting', 't' => 'Str' } ], 't' => 'MetaInlines' }
     },
     'pandoc-api-version' => [ 1, 17, 0, 4 ]
-  }, 'ast';
+};
 
-my $json = JSON->new->utf8->convert_blessed->encode($doc);
+my $json = JSON->new->utf8->convert_blessed->encode($ast);
 is_deeply decode_json($json), $ast, 'encode/decode JSON';
-is_deeply Pandoc::Elements::pandoc_json($json), $doc, 'pandoc_json';
-$json = $doc->to_json;
+is_deeply Pandoc::Elements::pandoc_json($json), $ast, 'pandoc_json';
+$json = $ast->to_json;
 is_deeply decode_json($json), $ast, 'to_json';
 
 eval { Pandoc::Elements->pandoc_json(".") };

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,37 +1,84 @@
 use strict;
 use Test::More;
+
 use Pandoc::Elements;
 use JSON;
 
-my $ast = Document { 
+# TODO: use Test::Deep::noclass() instead? See synopsis-noclass.t!
+#
+# HACK: De-objectify api-version so that tests pass.
+# This is a bug in Test::More::is_deeply(), not in Pandoc::Elements:
+# is_deeply() compares the stringification of overloaded objects,
+# even though it's supposed to compare data structures!
+# Test::Deep offers a non-broken way of doing this and more.
+    
+my $doc = Document { 
         title => MetaInlines [ Str 'Greeting' ] 
     }, [
         Header( 1, attributes { id => 'de' }, [ Str 'Gruß' ] ),
         Para [ Str 'hello, world!' ],
-    ];
+    ],
+    api_version_of => '1.18';
 
-is_deeply $ast, [ 
-    { 
-        unMeta => { 
-            title => { 
-                t => 'MetaInlines', 
-                c => [{ t => 'Str', c => 'Greeting' }]
-            }
-        } 
+#<<<
+is_deeply $doc,
+  bless(
+    { 'blocks' => [
+        bless(
+          { 'c' => [
+              1,
+              [ 'de', [], [] ],
+              [ bless( { 'c' => 'Gruß', 't' => 'Str' }, 'Pandoc::Document::Str' ) ]
+            ],
+            't' => 'Header'
+          },
+          'Pandoc::Document::Header'
+        ),
+        bless(
+          { 'c' => [
+              bless( { 'c' => 'hello, world!', 't' => 'Str' }, 'Pandoc::Document::Str' )
+            ],
+            't' => 'Para'
+          },
+          'Pandoc::Document::Para'
+        )
+      ],
+      'meta' => {
+        'title' => bless(
+          { 'c' =>
+              [ bless( { 'c' => 'Greeting', 't' => 'Str' }, 'Pandoc::Document::Str' ) ],
+            't' => 'MetaInlines'
+          },
+          'Pandoc::Document::MetaInlines'
+        )
+      },
+      'pandoc-api-version' => bless( [ 1, 17, 0, 4 ], 'Pandoc::Document::ApiVersion' )
     },
-    [ 
-        {
-          t => 'Header', 
-          c => [ 1, ['de',[],[]], [ { t => 'Str', c => 'Gruß' } ] ]
-        },
-        { t => 'Para', c => [ { t => 'Str', c => 'hello, world!' } ] } 
-    ]
-];
+    'Pandoc::Document'
+    ),
+  'document';
+#>>>
 
-my $json = JSON->new->utf8->convert_blessed->encode($ast);
+my $ast = $doc->TO_JSON;
+
+is_deeply $ast,
+  { 'blocks' => [
+        {   'c' => [ 1, [ 'de', [], [] ], [ { 'c' => 'Gruß', 't' => 'Str' } ] ],
+            't' => 'Header'
+        },
+        { 'c' => [ { 'c' => 'hello, world!', 't' => 'Str' } ], 't' => 'Para' }
+    ],
+    'meta' => {
+        'title' =>
+          { 'c' => [ { 'c' => 'Greeting', 't' => 'Str' } ], 't' => 'MetaInlines' }
+    },
+    'pandoc-api-version' => [ 1, 17, 0, 4 ]
+  }, 'ast';
+
+my $json = JSON->new->utf8->convert_blessed->encode($doc);
 is_deeply decode_json($json), $ast, 'encode/decode JSON';
-is_deeply Pandoc::Elements::pandoc_json($json), $ast, 'pandoc_json';
-$json = $ast->to_json;
+is_deeply Pandoc::Elements::pandoc_json($json), $doc, 'pandoc_json';
+$json = $doc->to_json;
 is_deeply decode_json($json), $ast, 'to_json';
 
 eval { Pandoc::Elements->pandoc_json(".") };


### PR DESCRIPTION
*   Accommodated for the new JSON style in a backwards-compatible way.

*   Added new LineBlock element with api-version sensitive TO_JSON()

    ```perl
    LineBlock [ @lines ]    # each line an arrayref of inlines
    ```

    Leading space characters (U+0020) on each line are converted to
    non-breaking spaces (U+00A0) when emitting JSON as Pandoc does.

*   Added various things to accomodate/use the new `pandoc-api-version` flag in the AST.

    The `pandoc-api-version` value in the Document object is an object with
    ~~overloaded stringification and numification~~ comparison methods.  That's a bit radical but
    allows for human-readable inspection and ~~use of perl's comparison operators~~ version comparison,
    which I think is essential.

    New functions `pandoc_api_version()` and `pandoc_api_version_of()`.
    Both return objects as per the preceding paragraph.
    `pandoc_api_version()` takes either a string representation like
    `'1.17.0.4'` or an arrayref like `[1,17,0,4]` as pandoc emits.
    `pandoc_api_version_of()` takes a pandoc executable version number
    as a string like `'1.18'`. The idea is that since the API version number
    is different from the executable version number and kind of hard to
    come by the module keeps a mapping from executable versions to API versions.

    The `Document` constructor now accepts any of the following argument styles:

    ```perl
    # old-style still works, implies empty API version
    Document { %meta }, [ @blocks ];               

    # easy upgrade
    Document { %meta }, [ @blocks ], $api_version; 

    # future-proof easy upgrade
    Document { %meta }, [ @blocks ], api_version => $api_version;

    # even easier upgrade
    Document { %meta }, [ @blocks ], api_version_of => $executable_version;

    # old-style data structure, implies empty API version
    Document [ {unMeta => \%meta}, [ @blocks ] ]

    # new-style data structure and/or hash with parameters
    Document {
        meta   => { %meta },        # defaults to empty hash
        blocks => [ @blocks ],      # defaults to empty array
        # these are all supported;
        # listed in order of preference;
        # defaults to $Pandoc::Elements::PANDOC_API_VERSION
        # if defined, else to undef = empty object
        'pandoc-api-version' => $api_version,        # e.g. '1.17.0.4'
        pandoc_api_version   => $api_version,
        api_version          => $api_version,
        api_version_of       => $executable_version, # e.g. '1.18'
    }
    ```

*   Added `Pandoc::Document::TO_JSON()` which localizes 
    `$Pandoc::Elements::PANDOC_API_VERSION` to the version
    stored in the Document, then calls the catchall `TO_JSON()`
    The latter now calls `TO_JSON()` if any on nested objects,
    so that the localized variable value propagates down the tree.
    Currently used by `Pandoc::Document::LineBlock::TO_JSON()`.

*   Added/tweaked tests which all pass (hopefully sensibly).

*   No documentation yet but lots of comments.

I did not do anything to distinguish between empty elements
like LineBreak with or without a dummy content array,
since [jgm says it's not necessary][pandocfilters]
and hasn't done so for jgm/pandocfilters.
We probably should add tests to make sure it really works. Will do.

[pandocfilters]: https://github.com/jgm/pandocfilters/commit/039dcc65bc10a14f9038a3671c795198bd50c15a#commitcomment-19579664

[1.18-commit.pod.zip](https://github.com/nichtich/Pandoc-Elements/files/561622/1.18-commit.pod.zip)
