### PR TITLE
Fatal typo at Elements.pm L 638

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -635,7 +635,7 @@ sub Pandoc::Document::MetaInlines::metavalue {
 }
 
 sub Pandoc::Document::MetaBlocks::metavalue {
-    join "\n", map { $_->string } @{$_[0]}->{c}
+    join "\n", map { $_->string } @{$_[0]->{c}}
 }
 
 sub Pandoc::Document::MetaList::metavalue {


### PR DESCRIPTION
```diff
 sub Pandoc::Document::MetaBlocks::metavalue {
-    join "\n", map { $_->string } @{$_[0]}->{c}
+    join "\n", map { $_->string } @{$_[0]->{c}}
 }
```
