### PR TITLE
$document->to_pandoc and friends didn't work as described

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -413,8 +413,8 @@ sub pandoc_json($) {
     }
     sub to_pandoc {
         my ($self, @args) = @_;
-        my $pandoc = (@_ and blessed($_[0]) and $_[0]->isa('Pandoc'))
-                   ? shift : pandoc;
+        my $pandoc = (@args and blessed($args[0]) and $args[0]->isa('Pandoc'))
+                   ? shift(@args) : pandoc;
 
         my $api_version = $self->api_version;   # save
         $self->pandoc_version( $pandoc->version );

--- a/t/to_pandoc.t
+++ b/t/to_pandoc.t
@@ -24,4 +24,9 @@ my $doc = pandoc->file('t/documents/outline.md');
     is $doc->to_markdown, $doc->to_pandoc( '-t' => 'markdown' ), 'to_markdown';
 }
 
+{
+    my $to_latex = new_ok Pandoc => [ '-t' => 'latex' ], 'to-latex-object';
+    is $doc->to_pandoc( $to_latex ), $doc->to_latex,'to latex with custom Pandoc';
+}
+
 done_testing;


### PR DESCRIPTION
The docs say

> The first argument can optionally be an instance of Pandoc to use a specific executable.

However to_pandoc first unpacked `my($self, @args) = @_` then looked if `$_[0]->isa('Pandoc')` rather than `$args[0]->isa('Pandoc')`.