### PR TITLE
silence uninitialized value in string eq warning with empty lines in lineblocks

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,4 +16,5 @@ on test => sub {
     requires 'Test::More', '0.96';
     requires 'Test::Output';
     requires 'Test::Exception';
+    requires 'Test::Warnings';
 };

--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -795,9 +795,7 @@ sub Pandoc::Document::LineBlock::TO_JSON {
 
         # Convert spaces at the beginning of each line
         # to Unicode non-breaking spaces, because pandoc does.
-        next unless 
-        @$line and 
-        $line->[0]->{t} eq 'Str';
+        next unless @$line and $line->[0]->{t} eq 'Str';
         $line->[0]->{c} =~ s{^(\x{20}+)}{ "\x{a0}" x length($1) }e;
     }
 

--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -795,7 +795,9 @@ sub Pandoc::Document::LineBlock::TO_JSON {
 
         # Convert spaces at the beginning of each line
         # to Unicode non-breaking spaces, because pandoc does.
-        next unless $line->[0]->{t} eq 'Str';
+        next unless 
+        @$line and 
+        $line->[0]->{t} eq 'Str';
         $line->[0]->{c} =~ s{^(\x{20}+)}{ "\x{a0}" x length($1) }e;
     }
 

--- a/t/lineblocks-empty-lines.t
+++ b/t/lineblocks-empty-lines.t
@@ -1,0 +1,39 @@
+use Test::More 0.96;
+# use Test::Deep qw[ :v1 ];
+use Test::Warnings qw[ warnings :no_end_test ];
+
+use Pandoc::Elements;
+use Pandoc;
+
+my $lineblock = <<'END_OF_MD';
+| Sven Svensson
+|
+|
+|
+| Tel: 0123-45 67 89
+| 
+| Adress:
+|
+| Storgatan 42
+| 123 45 Storstad
+| Sverige
+END_OF_MD
+
+my $doc = pandoc->parse(markdown => $lineblock);
+
+my $json;
+
+is_deeply [
+    warnings {
+        $json = $doc->to_json;
+    } 
+], [], 'uninitialized';
+
+is_deeply [
+    warnings {
+        my $doc = pandoc->parse( json => $json );
+    }
+], [], 'parse json';
+
+done_testing;
+


### PR DESCRIPTION
See the diff.  The test for a Str element would cause an "uninitialized value in string eq" warning if the `@$line` was empty, and what's worse it might autovivify an `undef` which would cause Pandoc to throw an invalid JSON error.