### PR TITLE
 Support fully compliant JSON Pointers as well as old style metavalue keys

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -317,7 +317,9 @@ sub citation($) {
     };
 }
 
-use Pandoc::Metadata ();
+# XXX: must require rather than use Pandoc::Metadata
+# or its attempt to use Pandoc::Elements will result in a broken state.
+require Pandoc::Metadata;
 
 sub metadata($);  ## no critic
 

--- a/lib/Pandoc/Metadata.pm
+++ b/lib/Pandoc/Metadata.pm
@@ -13,6 +13,11 @@ use JSON::PP;
     # key-value map of metadata fields
     package Pandoc::Document::Metadata;
 
+    {
+        no warnings 'once';
+        *to_json = \&Pandoc::Document::Element::to_json;
+    }
+
     sub TO_JSON {
         return { map { $_ => $_[0]->{$_} } keys %{ $_[0] } };
     }

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -42,8 +42,8 @@ foreach (0, '', 'false', 'FALSE', undef) {
     is '{"c":false,"t":"MetaBool"}', $m->to_json, "false: $_";
 }
 
-is_deeply $doc->value('true', boolean => 'JSON::PP'), JSON::PP::true, 'JSON::PP::true'; 
-is_deeply $doc->value('false', boolean => 'JSON::PP'), JSON::PP::false, 'JSON::PP::false'; 
+is_deeply $doc->value('/true', boolean => 'JSON::PP'), JSON::PP::true, 'JSON::PP::true'; 
+is_deeply $doc->value('/false', boolean => 'JSON::PP'), JSON::PP::false, 'JSON::PP::false'; 
 
 # MetaString
 
@@ -79,21 +79,30 @@ is_deeply $doc->value, {
   }, 'value';
 
 is $doc->value('false'), 0, 'value("false")';
+is $doc->value('/false'), 0, 'value("/false")';
 is $doc->value('true'), 1, 'value("true")';
-is $doc->value('map/string'), "0", 'value("map/string")';
-is $doc->value('map/list/0'), "a", 'value("map/list/0")';
-is $doc->value('map/list/2'), "0", 'value("map/list/2")';
+is $doc->value('/true'), 1, 'value("/true")';
+is $doc->value('/map/string'), "0", 'value("/map/string")';
+is $doc->value('/map/list/0'), "a", 'value("/map/list/0")';
+is $doc->value('/map/list/2'), "0", 'value("/map/list/2")';
 is $doc->value('string'), "hello\nworld", 'value("string")';
-is_deeply $doc->value('map/~1~0', boolean => 'JSON::PP'),
-    JSON::PP::true, 'value("map/~1~0")';
+is $doc->value('/string'), "hello\nworld", 'value("/string")';
+is_deeply $doc->value('/map/~1~0', boolean => 'JSON::PP'),
+    JSON::PP::true, 'value("/map/~1~0")';
 is_deeply $doc->value('string', element => 'keep'),
     $doc->meta->{string}->content, 'value("string", elements => keep)';
+is_deeply $doc->value('/string', element => 'keep'),
+    $doc->meta->{string}->content, 'value("/string", elements => keep)';
 is $doc->value('blocks'), "x\n\ny", 'value("blocks")';
+is $doc->value('/blocks'), "x\n\ny", 'value("/blocks")';
 is_deeply $doc->value('blocks', element => 'keep'),
     $doc->meta->{blocks}->content, 'value("blocks", elements => keep)';
+is_deeply $doc->value('/blocks', element => 'keep'),
+    $doc->meta->{blocks}->content, 'value("/blocks", elements => keep)';
 
 foreach (qw(x map/x true/x blocks/x map/list/x map/list/3)) {
     is $doc->value($_), undef, "value('$_')";
+    is $doc->value($_), undef, "value('/$_')";
 }
 
 my $doc = do {

--- a/t/pointer.t
+++ b/t/pointer.t
@@ -1,0 +1,157 @@
+
+use 5.010001;
+use strict;
+use warnings;
+
+use Test::More 0.96;
+use Test::Exception;
+
+use Pandoc::Elements;
+
+
+# Make sure examples from  RFC 6901 sec 5 work as metadata
+
+my $doc = pandoc_json(<<'JSON');
+[ { "unMeta": {
+    "":{"c":"0","t":"MetaString"},
+    " ":{"c":"7","t":"MetaString"},
+    "a/b":{"c":"1","t":"MetaString"},
+    "c%d":{"c":"2","t":"MetaString"},
+    "e^f":{"c":"3","t":"MetaString"},
+    "foo":{"c":[
+            {"c":[{"c":"bar","t":"Str"}],"t":"MetaInlines"},
+            {"c":[{"c":"baz","t":"Str"}],"t":"MetaInlines"}
+        ],"t":"MetaList"},
+    "g|h":{"c":"4","t":"MetaString"},
+    "i\\j":{"c":"5","t":"MetaString"},
+    "k\"l":{"c":"6","t":"MetaString"},
+    "m~n":{"c":"8","t":"MetaString"}
+} }, [] ]
+JSON
+
+my @tests = (
+    [   'RFC 6901' => [
+            [ ""       => $doc->value ],
+            [ "/foo"   => [ "bar", "baz" ] ],
+            [ "/foo/0" => "bar" ],
+            [ "/"      => 0 ],
+            [ "/a~1b"  => 1 ],
+            [ "/c%d"   => 2 ],
+            [ "/e^f"   => 3 ],
+            [ "/g|h"   => 4 ],
+            [ "/i\\j"  => 5 ],
+            [ "/k\"l"  => 6 ],
+            [ "/ "     => 7 ],
+            [ "/m~0n"  => 8 ],
+        ],
+    ],
+
+    # If the 'pointer' string does not start with a forward
+    # slash or is empty the whole string is one "old-style" key.
+    [   'old-style' => [
+            [ "foo"   => [ "bar", "baz" ] ],
+            [ "foo/0" => undef ],
+            [ "a/b"   => 1 ],
+            [ "c%d"   => 2 ],
+            [ "e^f"   => 3 ],
+            [ "g|h"   => 4 ],
+            [ "i\\j"  => 5 ],
+            [ "k\"l"  => 6 ],
+            [ " "     => 7 ],
+            [ "m~n"   => 8 ],
+        ],
+    ],
+);
+
+
+
+for my $test ( @tests ) {
+    my($name, $subtests) = @$test;
+    subtest $name => sub {
+        for my $subtest ( @$subtests ) {
+            my ( $pointer, $expected ) = @$subtest;
+            my $value = $doc->value( $pointer );
+            is_deeply $value, $expected, "'$pointer'"
+            or note explain { got => $value, expected => $expected };
+            next unless defined $expected;
+            lives_ok { $doc->value( $pointer, strict => 1 ) } "'$pointer' strict";
+        }
+    };
+}
+
+subtest strict => sub {
+    my @tests = (
+        [   '/foo/2' =>
+              qr{\QList index 2 out of range in (sub)pointer "/2" in pointer "/foo/2"\E}
+        ],
+        [   '/foo/bar' =>
+              qr{\QNode "/bar" not a valid list index in (sub)pointer "/bar" in pointer "/foo/bar"\E}
+        ],
+        [   '/quux' =>
+              qr{\QNode "/quux" doesn't correspond to any key in (sub)pointer "/quux" in pointer "/quux"\E}
+        ],
+        [   'quux' =>
+              qr{\QNode "quux" doesn't correspond to any key in (sub)pointer "quux" in pointer "quux"\E}
+        ],
+        [   '/e^f/g/h' =>
+              qr{\QNo list or mapping "/g" in (sub)pointer "/g/h" in  pointer "/e^f/g/h"\E}
+        ],
+    );
+    for my $test ( @tests ) {
+        my ( $pointer, $regex ) = @$test;
+        throws_ok { $doc->value( $pointer, strict => 1 ) } $regex,
+          "'$pointer' throws";
+    }
+};
+
+done_testing;
+
+
+__END__
+   {
+      "foo": ["bar", "baz"],
+      "": 0,
+      "a/b": 1,
+      "c%d": 2,
+      "e^f": 3,
+      "g|h": 4,
+      "i\\j": 5,
+      "k\"l": 6,
+      " ": 7,
+      "m~n": 8
+   }
+
+   The following JSON strings evaluate to the accompanying values:
+
+    ""           // the whole document
+    "/foo"       ["bar", "baz"]
+    "/foo/0"     "bar"
+    "/"          0
+    "/a~1b"      1
+    "/c%d"       2
+    "/e^f"       3
+    "/g|h"       4
+    "/i\\j"      5
+    "/k\"l"      6
+    "/ "         7
+    "/m~0n"      8
+
+my $doc = pandoc->parse( markdown => <<'END_OF_MD', '--standalone' );
+---
+foo:
+- bar
+- baz
+'': 0
+a/b: 1
+c%d: 2
+e^f: 3
+g|h: 4
+i\j: 5
+k"l: 6
+' ': 7
+m~n: 8
+...
+END_OF_MD
+
+say $doc->meta->to_json;
+


### PR DESCRIPTION
I think I've found a nice way to make `*::Meta*->value` both mostly backwards compatible *and* fully JSON Pointer compliant:

*   Each reference token starts with a forward slash which is followed by zero or more non-slash characters, i.e. it matches the regex `qr{ / [^/]* }msx`.

*   A compliant pointer consists of zero or more such reference tokens.

*   An empty-string `pointer` value means the whole document should be returned.

*   A reference token consisting of a lone forward slash (`/`) is valid and causes the mapping value whose key is an empty string to be returned.

*   The non-compliant part:

    I think the best way to retain as much backward compatibility as possible is to assume that a `pointer` value which starts with any character *except* forward slash is an old-style key, and use it as-is without any JSON Pointer unescaping.  There will still be two edge cases where a key in an old-style program starts with a slash or is an empty string meaning the empty-string key, but that's hard to work around other than putting a warning in the documentation.

Our JSON Pointer use case is a bit different from the canonical use case, since we not only worm into an existing plain data structure but descend into a structure of objects and convert those objects into plain data as we go.  I believe that the best way to do this is to nibble one token at a time from the start of the pointer string, matching one of three possible tokens:

1.  An empty string, matching `qr{ \A\z }msx`, which causes the whole current object to be converted and returned.

2.  A reference token, matching `qr{ \A / ( [^/]* ) }msx`, which causes the value at the mapping key or list index corresponding to the captured part to be returned.

3.  An old-style (backwards compatible) key, matching `qr{ \A [^/] .* \z }msx`, counting the whole string as a mapping key without escapes.

Additionally the rest of the string, which may be empty, is captured into a "next pointer" field for convenience.

The nibbler function receives the caller `*::value` method's options, matches the current pointer against a regex with named captures corresponding to the previous pointer, the current reference token, the current key and the next pointer (the possibly empty rest of the previous pointer) and returns the options as modified/augmented by the named captures of the parser regex, whose names as private/internal values all start with an underscore.

I also added a `strict` option which triggers a mode, probably mainly useful for debugging -- if you get an `undef` back you may want to know why -- although I can see other use cases as well. In this mode the method will `croak` if an invalid pointer, invalid array index, non-existing key or non-existing array index is encountered.  This feature is however easy to remove without affecting the functionality of the rest.

I have updated `metadata.t` to use this syntax, as well as testing the `old-style` syntax where appropriate, and added a `pointer.t` which checks that the examples from [page 5 of RFC 6901](https://tools.ietf.org/html/rfc6901#page-5) work, as well as testing the `strict` mode with valid and invalid data.

I have another enhancement in the works which adds an option which causes `*::Meta*->value` to wrap the contents of MetaString, MetaBool, MetaInlines and/or MetaBlocks in a Span or Div element object with configurable attributes for each kind of meta element -- of course with the MetaString or MetaBool value as a Str element inside the Span.  I want to know what you think about this pointer idea first, since the "wrapper" code needs to be manually integrated with the pointer enhancement code if the latter is adopted.

I also discovered that `Pandoc::Elements`' `use`ing `Pandoc::Metadata` which itself `use`s `Pandoc::Elements` will cause `Pandoc::Metadata`'s imports from `Pandoc::Elements` to be broken, probably because not all the subroutines exported by `Pandoc::Elements` are defined at the time it imports `Pandoc::Metadata`. Replacing `use Pandoc::Metadata ();` with `require Pandoc::Metadata;` solves the problem.
