### PR TITLE
make citations objects with accessors for fields

### DIFF
--- a/lib/Pandoc/Elements.pm
+++ b/lib/Pandoc/Elements.pm
@@ -117,7 +117,7 @@ our %ELEMENTS = (
     Subscript   => [ Inline => 'content' ],
     SmallCaps   => [ Inline => 'content' ],
     Quoted      => [ Inline => qw(type content) ],
-    Cite        => [ Inline => qw(citations content) ],
+    Cite        => [ Inline => qw(citations:[Citation] content) ],
     Code        => [ Inline => qw(attr content) ],
     Space       => ['Inline'],
     SoftBreak   => ['Inline'],
@@ -298,20 +298,7 @@ sub attributes($) {
     return $e->attr;
 }
 
-sub citation($) {
-    my $a = shift;
-    {
-        citationId     => $a->{id}     // "missing",
-        citationPrefix => $a->{prefix} // [],
-        citationSuffix => $a->{suffix} // [],
-        citationMode   => $a->{mode}   // bless(
-            { t => 'NormalCitation', c => [] },
-            'Pandoc::Document::NormalCitation'
-        ),
-        citationNoteNum => $a->{num}  // 0,
-        citationHash    => $a->{hash} // 1,
-    };
-}
+sub citation($) { Pandoc::Document::Citation->new( @_ ) }
 
 # XXX: must require rather than use Pandoc::Metadata
 # or its attempt to use Pandoc::Elements will result in a broken state.
@@ -684,6 +671,78 @@ sub pandoc_json($) {
     }
 }
 
+{
+    package Pandoc::Document::Citation;
+    our $VERSION = $PANDOC::Document::VERSION;
+
+    use Carp qw[ carp croak ];
+
+    my %props = (
+        id     => { key => 'citationId',      default => '"missing"' },
+        prefix => { key => 'citationPrefix',  default => '[]' },
+        suffix => { key => 'citationSuffix',  default => '[]' },
+        num    => { key => 'citationNoteNum', default => '0' },
+        hash   => { key => 'citationHash',    default => '1' },
+        mode   => {
+            key     => 'citationMode',
+            default => q{
+            bless(
+                { t => 'NormalCitation', c => [] },
+                'Pandoc::Document::NormalCitation'
+              )
+        },
+        },
+    );
+
+    {
+        my $template = <<'END_OF_TEMPLATE';
+#line 1 "method [[[method]]]()"
+package Pandoc::Document::Citation;
+sub [[[method]]] {
+    my $self = shift;
+    if ( @_ ) {
+        $self->{[[[key]]]} = [[[coerce]]] ( shift // [[[default]]] );
+    }
+    return [[[coerce]]] ( $self->{[[[key]]]} //= [[[default]]] );
+}
+no warnings 'once';
+*[[[alias]]] = \&[[[method]]];
+1;
+END_OF_TEMPLATE
+
+        while ( my ( $name, $prop ) = each %props ) {
+            $prop->{name}   = $name;
+            $prop->{method} = "Pandoc::Document::Citation::$name";
+            $prop->{alias}  = "Pandoc::Document::Citation::$prop->{key}";
+            $prop->{coerce}
+              = $prop->{default} =~ /^\d$/ ? '0 +'
+              : $prop->{default} =~ /^"/   ? '"" .'
+              :                              "";
+            {
+                ( my $source = $template ) =~ s/\Q[[[\E(\w+)\Q]]]\E/$prop->{$1}/g;
+                local $@;
+                ## no critic
+                eval $source || croak $@ . $source;
+            }
+        }
+    }
+
+    my %accessors = map { ; $_->{name} => $_->{key} } values %props;
+
+    sub new {
+        my ( $class, $arg ) = @_;
+        my $self = bless {}, $class;
+        while ( my ( $name, $key ) = each %accessors ) {
+            # coerce on access
+            $self->$name( $arg->{$key} // $arg->{$name} );
+        }
+        return $self;
+    }
+
+    no warnings 'once';
+    *TO_JSON = \&Pandoc::Document::Element::TO_JSON;
+}
+
 # Special TO_JSON methods to coerce data to int/number/Boolean as appropriate
 # and to downgrade document model depending on pandoc_version
 
@@ -917,13 +976,13 @@ See L<attribute methods|/ATTRIBUTE METHODS> for details.
 =head2 citation { ... }
 
 A citation as part of document element L<Cite|/Cite> must be a hash reference
-with fields C<citationID> (string), C<citationPrefix> (list of L<inline
+with fields C<citationId> (string), C<citationPrefix> (list of L<inline
 elements|/INLINE ELEMENTS>) C<citationSuffix> (list of L<inline
 elements|/INLINE ELEMENTS>), C<citationMode> (one of C<NormalCitation>,
 C<AuthorInText>, C<SuppressAuthor>), C<citationNoteNum> (integer), and
 C<citationHash> (integer). The helper method C<citation> can be used to
-construct such hash by filling in default values and using shorter field names
-(C<id>, C<prefix>, C<suffix>, C<mode>, C<note>, and C<hash>):
+construct such a hash by filling in default values and optionally using 
+shorter field names (C<id>, C<prefix>, C<suffix>, C<mode>, C<note>, and C<hash>):
 
     citation {
         id => 'foo',
@@ -934,6 +993,12 @@ construct such hash by filling in default values and using shorter field names
     # in Pandoc Markdown
 
     [see @foo p. 42]
+
+The values returned by this function, as well as any citations contained in
+document objects returned by C<pandoc_json>, are blessed hashrefs with
+getter/setter accessors corresponding to both the full and short field
+names, so that e.g. C<< $citation->citationId(...) >> and
+C<< $citation->id(...) >> get or set the same value.
 
 =head2 pandoc_version( [ $document ] )
 

--- a/t/citation.t
+++ b/t/citation.t
@@ -1,12 +1,39 @@
 use strict;
-use Test::More;
+use Test::More 0.96; # 0.96 for subtests
 use Pandoc::Elements;
+
+use constant STRINGLIKE => 'Pandoc::Document::Citation::Test::Stringlike';
+
+{
+    package # no index
+        Pandoc::Document::Citation::Test::Stringlike;
+    use overload q[""] => sub {  ${$_[0]} }, fallback => 1;
+    sub new {
+        my($class, $value) = @_;
+        return bless \$value => $class;
+    }
+}
+
+my @accessors = (
+    [ hash   => "citationHash" ],
+    [ id     => "citationId" ],
+    [ mode   => "citationMode" ],
+    [ num    => "citationNoteNum" ],
+    [ prefix => "citationPrefix" ],
+    [ suffix => "citationSuffix" ],
+);
+
+my @methods = qw[ new TO_JSON ], map {; @$_ } @accessors;
 
 my $c = citation { 
         id => 'foo', 
         prefix => [ Str "see" ], 
         suffix => [ Str "p.", Space, Str "42" ]
     };
+
+isa_ok $c, 'Pandoc::Document::Citation';
+
+can_ok $c, @methods;
 
 is_deeply $c, {
    citationId => 'foo',
@@ -15,6 +42,36 @@ is_deeply $c, {
    citationNoteNum => 0,
    citationPrefix => [ Str "see" ],
    citationSuffix => [ Str "p.", Space, Str "42" ],
+}, 'structure';
+
+subtest accessors => sub {
+    for my $aliases ( @accessors ) {
+        my($name, $key) = @$aliases;
+        is_deeply $c->$name, $c->{$key}, $name;
+        is_deeply $c->$key, $c->{$key}, $key;
+        is_deeply $c->$key, $c->$name, "$key/$name";
+    }
+};
+
+subtest id => sub {
+    my $bar = STRINGLIKE->new('bar');
+    my $baz = STRINGLIKE->new('baz');
+    isa_ok $bar, STRINGLIKE, 'test object';
+    my $c = citation { id => $bar };
+    is $c->id, 'bar', 'initial value';
+    ok !ref($c->id), 'coercion through constructor';
+    $c->id($baz);
+    is $c->id, 'baz', 'changed value';
+    ok !ref($c->id), 'coercion through setter';
+};
+
+my $doc = pandoc_json(<<'END_OF_JSON');
+{"blocks":[{"t":"Para","c":[{"t":"Cite","c":[[{"citationSuffix":[],"citationNoteNum":0,"citationMode":{"t":"NormalCitation"},"citationPrefix":[],"citationId":"foo","citationHash":0}],[{"t":"Str","c":"[@foo]"}]]}]}],"pandoc-api-version":[1,17,5,1],"meta":{}}
+END_OF_JSON
+
+subtest 'blessed by document constructor' => sub {
+    my $cites = $doc->query( Cite => sub { $_ } );
+    isa_ok eval { $cites->[0]->citations->[0] }, 'Pandoc::Document::Citation';
 };
 
 done_testing;


### PR DESCRIPTION
As it says.  I got tired of (mis)typing `$citation->citationId` instead of `$citation->id`!  :-)