### PR TITLE
ImagesFromCode: fix/extend figure output and figure captions

### DIFF
--- a/lib/Pandoc/Filter/ImagesFromCode.pm
+++ b/lib/Pandoc/Filter/ImagesFromCode.pm
@@ -7,12 +7,14 @@ use 5.010;
 
 our $VERSION = '0.36';
 
+use Carp qw(croak);
 use Digest::MD5 'md5_hex';
 use IPC::Run3;
 use File::Spec::Functions;
 use File::stat;
 use Pandoc::Elements;
-use Scalar::Util 'reftype';
+use Pandoc;
+use Scalar::Util qw(blessed reftype);
 use parent 'Pandoc::Filter', 'Exporter';
 
 our @EXPORT_OK = qw(read_file write_file);
@@ -33,6 +35,8 @@ sub new {
     if ('ARRAY' ne reftype $opts{run} or !@{$opts{run}}) {
         die "missing or empty option: run\n";
     }
+
+    _verify_pandoc(\%opts);
 
     bless \%opts, $class;
 }
@@ -81,7 +85,7 @@ sub action {
         if (!$self->{force} and $in and $out and $in->mtime <= $out->mtime) {
             if ($code eq read_file($args{infile}, ':utf8')) {
                 # no need to rebuild the same outfile
-                return build_image($e, $args{outfile});
+                return $self->_build_image($e, $args{outfile});
             }
         }
 
@@ -111,7 +115,7 @@ sub action {
         # TODO: skip error if requested
         die $stderr if $stderr;
 
-        return build_image($e, $args{outfile});
+        return $self->_build_image($e, $args{outfile});
     }
 }
 
@@ -125,19 +129,55 @@ sub action {
 
 sub build_image {
     my $e = shift;
-    my $filename = shift // '';
+    my %opts = (@_%2) ? (filename => @_) : @_;
+    my $filename = $opts{filename} // '';
 
     my $keyvals = $e->keyvals;
     my $title = $keyvals->get('title') // '';
     my $img = Image attributes { id => $e->id, class => $e->class },
         [], [$filename, $title];
 
-    my $caption = $keyvals->get('caption') // '';
-    if (defined $caption) {
+    my $fig = $title =~ /^fig:/ || do {
+        my $fig_attr = $keyvals->get('fig') // "";
+        $fig_attr && ($fig_attr !~ /^false$/i);
+    };
+    # Support passing fig-caption with markdown/markup
+    if ( defined( my $text = $keyvals->get('fig-caption') ) ) {
+        _verify_pandoc( \%opts, $keyvals );
+        my $contents
+          = $opts{pandoc}->parse( "$opts{reader}$opts{reader_ext}" => $text )
+          ->query( 'Para|Plain' => sub { $_->content } );
+        if ( my @inlines = map {; @$_ } @$contents ) {
+            push @{$img->content}, @inlines;
+            $fig //= 1;
+        }
+    }
+    # XXX: distinguish between alt-text and caption ?
+    # elsif ( defined( my $alt = $keyvals->get('alt') ) ) {
+    #     push @{$img->content}, Str($alt);
+    #     $fig //= 0;
+    # }
+    elsif ( defined( my $caption = $keyvals->get('caption') ) ) {
         push @{$img->content}, Str($caption);
+        # XXX: distinguish between alt-text and caption ?
+        # $fig //= 1;
+    }
+    if ( $fig ) {
+        $img->title('fig:' . $title) unless $title =~ /^fig:/;
+        return Para [ $img ]; # Must be Para for fig: to work!
     }
 
     return Plain [ $img ];
+}
+
+# OO wrapper around function build_image
+# in order to set default opts from object
+sub _build_image {
+    my $self = shift;
+    my $e = shift;
+    my %opts = (@_%2) ? (filename => @_) : @_;
+    my %defaults = map {; $_ => $self->{$_} } qw( pandoc reader_ext reader );
+    return build_image($e, %defaults, %opts);
 }
 
 sub write_file {
@@ -161,6 +201,41 @@ sub read_file {
     return $content;
 }
 
+sub _verify_pandoc {
+    my($opts, $keyvals) = @_;
+    for my $pandoc ( $opts->{pandoc} ) {
+        if ( !defined($pandoc) ) {
+            $pandoc = pandoc;
+        } elsif ( !blessed($pandoc) ) {
+            'ARRAY' eq ref $pandoc or $pandoc = [$pandoc];
+            my $error = do {
+                local $@;
+                eval { $pandoc = Pandoc->new(@$pandoc); };
+                $@;
+            };
+            if ( $error ) {
+                croak "couldn't instantiate Pandoc.pm: $error";
+            }
+        } else {
+            $pandoc->isa('Pandoc')
+                or croak "expected option 'pandoc' to be Pandoc.pm parameters or instance";
+        }
+    }
+    if ( defined $keyvals ) {
+        for my $key ( qw[ reader_ext reader_exts reader ] ) {
+            $opts->{$key} //= "";
+            (my $attr = $key) =~ tr/_/-/;
+            $opts->{$key} = $keyvals->get($attr) // $opts->{$key};
+        }
+    }
+    ($opts->{reader_ext} //= "") .= ($opts->{reader_exts} // "");
+    $opts->{reader_ext} =~ /\A(?:[-+]\w+)*\z/
+        or croak "expected option 'reader_ext' to be string with zero or more +EXTENSION and/or -EXTENSION";
+    ($opts->{reader} //= 'markdown' ) =~ /\A(?!\d|_)\w+(?:[-+]\w+)*\z/
+        or croak "expected option 'reader' to be pandoc input format";
+    return $opts;
+}
+
 1;
 
 __END__
@@ -175,8 +250,81 @@ This L<Pandoc::Filter> transforms L<CodeBlock|Pandoc::Elements/CodeBlock>
 elements into L<Image|Pandoc::Elements/Image> elements. Content of transformed
 code section and resulting image files are written to files.
 
-Attribute C<title> is mapped to the image title and attribute C<caption> to
-an image caption, if available.
+=head2 Attributes
+
+The following attributes can be set on a CodeBlock to modify the output.
+
+=over
+
+=item title
+
+Mapped to the image title attribute.
+
+=item caption
+
+Mapped to the image caption/alt-text as a single unformatted string.
+
+Ignored if C<fig-caption> is also present.
+
+=for UNIMPLEMENTED:
+Ignored if C<alt> is also present.
+
+=begin UNIMPLEMENTED:
+
+=item alt
+
+Mapped to the image caption/alt-text as a single unformatted string.
+
+Ignored if C<fig-caption> is also present.
+
+=end UNIMPLEMENTED:
+
+=item fig
+
+If set to a true value the image will be output as a figure
+as per the Pandoc manual's description of the 
+L<< C<implicit_figures> extension|http://pandoc.org/MANUAL.html#extension-implicit_figures >>.
+
+This means that the Image element will be wrapped in a Para element rather than
+a Plain element and the image title will have a C<fig:> prefix (which the Pandoc
+writer will remove), so that the image is formatted as a figure by Pandoc writers
+which support this.
+
+In addition to customary Perl false values a value C<false> (case insensitive) is
+considered to be false.  All other non-empty non-zero values are considered true.
+
+=item fig-caption
+
+If present and non-empty the value of this attribute will be converted with
+L<Pandoc> and inserted as the caption of the image.
+
+Implies a true value for C<fig>.
+
+Use the C<caption> attribute unless you actually need the caption to contain 
+formatted text; C<fig-caption> is expensive as it needs to shell out to the C<pandoc>
+executable.  Cf. C<pandoc> under L<CONFIGURATION|/"CONFIGURATION"> below.
+
+Since you probably will enclose this attribute value in double quotes use
+the HTML C<&quot;> entity for embedded double quotes.
+Pandoc will do the right thing!
+
+=item reader
+
+=item reader-ext
+
+These attributes are only relevant if the C<fig-caption> attribute is also
+present and non-empty!
+
+See C<pandoc>, C<reader> and C<reader_ext> under L<CONFIGURATION|/"CONFIGURATION"> below.
+
+If C<reader> and/or C<reader-ext> are given as attributes they override the 
+corresponding constructor parameters.  Note the difference between
+e.g. C<reader="markdown+smart"> and C<reader-ext="+smart">:
+the value of C<reader-ext> will be appended to the value of C<reader>, or to 
+the value for C<reader> passed to the constructor if the C<reader> I<attribute>
+is missing.
+
+=back
 
 =head1 CONFIGURATION
 
@@ -189,7 +337,7 @@ File extension of input files extracted from code blocks. Defaults to C<code>.
 =item to
 
 File extension of created image files. Can be a fixed string or a code reference that
-gets the document output format (for instance L<latex> or C<html>) as argument to
+gets the document output format (for instance C<latex> or C<html>) as argument to
 produce different image formats depending on output format.
 
 =item name
@@ -221,6 +369,40 @@ Capture output of command and write it to C<outfile>. Disabled by default.
 
 Apply transformation also if input and output file already exists unchanged.
 Disabled by default.
+
+=item pandoc
+
+A string containing the path to or name of the C<pandoc> executable to use
+to convert any C<fig-caption> attributes as described under
+L<Attributes|/"Attributes"> above.
+
+If this is an array reference instead of a string the contents of the array
+will be passed as arguments to the constructor of the
+L<Pandoc|Pandoc/"METHODS"> module.
+
+You can also pass an instance of the L<Pandoc> class.
+
+You shouldn't provide any C<--from> or C<--to> options (or their aliases)
+as these will be overridden on each invocation. Use C<reader> or
+C<reader_ext> or their corresponding L<attributes|/"Attributes">
+to set the input format.
+
+If this parameter is omitted or undefined the defaults as described in
+the L<Pandoc> module will be used.
+
+=item reader
+
+The pandoc reader to use when converting C<fig-caption> L<attributes|/"Attributes">.
+Defaults to C<markdown>. Can be overridden on a per-image basis through the 
+C<reader> L<attribute/"Attributes">.
+
+=item reader_ext
+
+A string containing zero or more C<+PANDOC_EXTENSION> and/or
+C<-PANDOC_EXTENSION> substrings. Will be appended to the C<reader>
+parameter or to any C<reader> L<attribute|/"Attributes"> which overrides
+it, unless itself overridden by a C<reader-ext> attribute which will be
+used instead of it if present.
 
 =back
 

--- a/t/Filter-ImagesFromCode-figure.t
+++ b/t/Filter-ImagesFromCode-figure.t
@@ -7,7 +7,7 @@ use Pandoc;
 use Pandoc::Filter::ImagesFromCode;
 use File::Temp 'tempdir';
 
-if ( pandoc->version < 1.18 ) {
+if ( pandoc->version < 1.16 ) {
     plan skip_all => 'pandoc executable is too old for these tests (< 1.18)';
 }
 

--- a/t/Filter-ImagesFromCode-figure.t
+++ b/t/Filter-ImagesFromCode-figure.t
@@ -7,7 +7,7 @@ use Pandoc;
 use Pandoc::Filter::ImagesFromCode;
 use File::Temp 'tempdir';
 
-if ( pandoc->version < 1.16 ) {
+unless ( pandoc and pandoc->version >= 1.18 ) {
     plan skip_all => 'pandoc executable is too old for these tests (< 1.16)';
 }
 

--- a/t/Filter-ImagesFromCode-figure.t
+++ b/t/Filter-ImagesFromCode-figure.t
@@ -1,0 +1,118 @@
+use strict;
+use warnings;
+
+use Test::More 0.98; # subtests
+use Pandoc::Elements;
+use Pandoc;
+use Pandoc::Filter::ImagesFromCode;
+use File::Temp 'tempdir';
+
+if ( pandoc->version < 1.18 ) {
+    plan skip_all => 'pandoc executable is too old for these tests (< 1.18)';
+}
+
+my $dir = tempdir( CLEANUP => 1 );
+
+my $perlcode = 'print "Totally ignored! :-)";';
+
+my %for_attr = (
+    id      => 'x',
+    title   => 'a title',
+    class   => 'perl',
+    caption => 'a caption',
+    fig     => 1,
+);
+
+my %for_filter = (
+    dir     => $dir,
+    from    => 'pl',
+    to      => 'txt',
+    capture => 1,
+    run     => [ 'perl', '$infile$' ],
+);
+
+my @fig_tests = (
+    {   name   => 'figure',
+        attr   => {%for_attr},
+        filter => {%for_filter},
+        json   => [
+            [ qr/"t":"Para"/,  'wrapped in Para' ],
+            [ qr/fig:a title/, 'fig: prefix' ],
+        ],
+        html => [
+            [ qr{<figure>.*</figure>}s,               'figure' ],
+            [ qr{<figcaption>a caption</figcaption>}, 'figcaption' ],
+        ]
+    },
+    {   name => 'fig-caption',
+        attr => {
+            %for_attr,
+            'fig-caption' => "This is a &quot;real&quot;, *styled* caption",
+        },
+        filter => {%for_filter},
+        json   => [],
+        html   => [
+            [   qr{<figcaption>This is a “real”, <em>styled</em> caption</figcaption>},
+                'figcaption'
+            ],
+        ],
+    },
+    {   name => 'pandoc',
+        attr =>
+          { %for_attr, 'fig-caption' => "This is a &quot;real&quot; caption", },
+        filter => { %for_filter, pandoc => [ 'pandoc', '--standalone' ] },
+        json   => [],
+        html   => [
+            [   qr{<figcaption>This is a “real” caption</figcaption>},
+                'figcaption'
+            ],
+        ],
+    },
+    {   name => 'no smart',
+        attr =>
+          { %for_attr, 'fig-caption' => "This is a &quot;real&quot; caption", },
+        filter => { %for_filter, reader_exts => '-smart' },
+        json   => [ [ qr{"c":"\\"real\\"","t":"Str"}, 'dumb quotes in JSON' ] ],
+        html =>
+          [ [ qr{This is a &quot;real&quot; caption}, 'dumb quotes in HTML' ], ],
+    },
+    {   name => 'smart anyway',
+        attr => {
+            %for_attr,
+            'reader-ext'  => '+smart',
+            'fig-caption' => "This is a &quot;real&quot; caption",
+        },
+        filter => { %for_filter, reader_exts => '-smart' },
+        json   => [ [ qr/"t":"DoubleQuote"/, 'DoubleQuote' ] ],
+        html   => [ [ qr{This is a “real” caption}, 'smart quotes' ], ],
+    },
+);
+
+for my $test ( @fig_tests ) {
+    subtest $test->{name} => sub {
+        my $doc = Document {}, [ CodeBlock attributes $test->{attr}, $perlcode ];
+
+        my $filter = Pandoc::Filter::ImagesFromCode->new( %{$test->{filter}});
+
+        $filter->apply($doc);
+
+        my $json = $doc->to_json;
+
+        # note $json;
+
+        for my $json_test ( @{$test->{json}} ) {
+            &like( $json, @$json_test ); # bypass prototype
+        }
+
+        my $html = $doc->to_pandoc( -t => 'html5' );
+
+        # note $html;
+
+        for my $html_test ( @{$test->{html}} ) {
+            &like( $html, @$html_test ); # bypass prototype
+        }
+
+    };
+}
+
+done_testing;

--- a/t/Filter-ImagesFromCode-figure.t
+++ b/t/Filter-ImagesFromCode-figure.t
@@ -8,7 +8,7 @@ use Pandoc::Filter::ImagesFromCode;
 use File::Temp 'tempdir';
 
 unless ( pandoc and pandoc->version >= 1.18 ) {
-    plan skip_all => 'pandoc executable is too old for these tests (< 1.16)';
+    plan skip_all => 'pandoc >= 1.18 not available';
 }
 
 my $dir = tempdir( CLEANUP => 1 );
@@ -44,10 +44,10 @@ my @fig_tests = (
             [ qr{<figcaption>a caption</figcaption>}, 'figcaption' ],
         ]
     },
-    {   name => 'fig-caption',
+    {   name => 'formatted caption',
         attr => {
             %for_attr,
-            'fig-caption' => "This is a &quot;real&quot;, *styled* caption",
+            'caption' => "This is a &quot;real&quot;, *styled* caption",
         },
         filter => {%for_filter},
         json   => [],
@@ -57,10 +57,10 @@ my @fig_tests = (
             ],
         ],
     },
-    {   name => 'pandoc',
+    {   name => 'pandoc and inlines',
         attr =>
-          { %for_attr, 'fig-caption' => "This is a &quot;real&quot; caption", },
-        filter => { %for_filter, pandoc => [ 'pandoc', '--standalone' ] },
+          { %for_attr, 'caption' => "This is a &quot;real&quot; caption", },
+        filter => { %for_filter, pandoc => Pandoc->new( 'pandoc', '--standalone' ) },
         json   => [],
         html   => [
             [   qr{<figcaption>This is a “real” caption</figcaption>},
@@ -70,8 +70,8 @@ my @fig_tests = (
     },
     {   name => 'no smart',
         attr =>
-          { %for_attr, 'fig-caption' => "This is a &quot;real&quot; caption", },
-        filter => { %for_filter, reader_exts => '-smart' },
+          { %for_attr, 'caption' => "This is a &quot;real&quot; caption", },
+        filter => { %for_filter, pandoc_format => '-smart' },
         json   => [ [ qr{"c":"\\"real\\"","t":"Str"}, 'dumb quotes in JSON' ] ],
         html =>
           [ [ qr{This is a &quot;real&quot; caption}, 'dumb quotes in HTML' ], ],
@@ -79,10 +79,10 @@ my @fig_tests = (
     {   name => 'smart anyway',
         attr => {
             %for_attr,
-            'reader-ext'  => '+smart',
-            'fig-caption' => "This is a &quot;real&quot; caption",
+            'pandoc-format'  => '+smart',
+            'caption' => "This is a &quot;real&quot; caption",
         },
-        filter => { %for_filter, reader_exts => '-smart' },
+        filter => { %for_filter, pandoc_format => '-smart' },
         json   => [ [ qr/"t":"DoubleQuote"/, 'DoubleQuote' ] ],
         html   => [ [ qr{This is a “real” caption}, 'smart quotes' ], ],
     },

--- a/t/Filter-ImagesFromCode-figure.t
+++ b/t/Filter-ImagesFromCode-figure.t
@@ -8,7 +8,7 @@ use Pandoc::Filter::ImagesFromCode;
 use File::Temp 'tempdir';
 
 if ( pandoc->version < 1.16 ) {
-    plan skip_all => 'pandoc executable is too old for these tests (< 1.18)';
+    plan skip_all => 'pandoc executable is too old for these tests (< 1.16)';
 }
 
 my $dir = tempdir( CLEANUP => 1 );


### PR DESCRIPTION
This PR fixes and extends output as figures and figure captions in Pandoc::Filter::ImagesFromCode.

## Figures

For an Image to be output as a [figure][] Pandoc writers currently require the following criteria to be fulfilled:

1.  The Image `title` must have a prefix `fig:` with or without any following title text.

    This prefix is normally added by the reader and tells the writer that the Image is to be formatted as a figure. The HTML writer(s) remove(s) this prefix.

    This magic prefix was introduced before Image elements took attributes; jgm has repeatedly referred to it as a hack, but no class or attribute has as yet been introduced as an alternative or replacement.

2.  The Image element must be the only content of a *Para* element.  A Plain element around the Image will not work.

To this end this PR introduces support for a `fig` attribute on the CodeBlock.  Specifying this attribute with a Perl true value which does not match `m/^false$/i` changes the return value of `build_image()` so that the Image title gets a `fig:` prefix if not already present, and the Image is wrapped in a Para rather than in a Plain.

If a `fig:` prefix already is present on the Image title this implies a true value for the `fig` attribute.

[figure]: http://pandoc.org/MANUAL.html#extension-implicit_figures

## Figure captions

With figures the need sometimes arises to include formatted text in captions.  To this end the PR additionally introduces a `fig-caption` attribute as a (higher precedence) alternative to the `caption` attribute.  If `fig-caption` is non-empty its text is parsed with Pandoc.pm module and the contents of any Para or Plain elements in the output are appended to the Image content (which ends up as the caption text).

To allow the user to influence the conversion of the `fig-caption` attribute the following constructor parameters and CodeBlock attributes are added:

*   `pandoc`

    This can be either a string containing the path/name of a pandoc executable, an array ref containing arguments to the Pandoc module's constructor or an instance of the Pandoc class.

*   `reader` or CodeBlock attribute `reader`

    The pandoc reader to use when parsing the `fig-caption` attribute.  It naturally defaults to `markdown`.  I don't honestly know if Pandoc::Filter::ImagesFromCode will work with any input format other than Markdown, but this gives some flexibility if this is or becomes the case.

*   `reader_ext` or CodeBlock attribute `reader-ext`

    While Pandoc extensions of course can be specified in the `reader` parameter/attribute this parameter/attribute has the advantage that its value will be appended to the value of the `reader` parameter or a `reader` attribute which overrides it, or the default reader if neither is present, on a per-CodeBlock basis.

As an alternative to a separate `fig-caption` attribute it may work to match the value of the `caption` attribute against the regex `/[^\P{PosixPunct}\p{Term}()+%#]/` to check if pandoc needs to be invoked.  That regex matches all POSIX punctuation --- i.e. those ASCII characters one would think of as punctuation --- *except* `! , . : ; ? ( ) + % #`, i.e. it will give a positive for text which does contain Pandoc Markdown inline constructs and give a negative for most text which doesn't contain any inline constructs, so that the filter doesn't shell out to pandoc when not needed.  Note that although `!` is part of the Image syntax that syntax also requires `[ ]` which will match.  Note that it is not good enough to match block constructs since `:` on its own can signal a definition list! The regex also deliberately excludes `%` and `#` which are part of block constructs but not of inline constructs. Of course 
`/[\-\"\$\&\'\*\/\<\=\>\@\[\\\]\^\_\`\{\|\}\~]/`
would match the same things, but is about twice as long and less self-explaining than the properties, even if all not strictly needed backslashes are removed.

## Tests

I have added some tests in `t/Filter-ImagesFromCode-figure.t`.