### PR TITLE
Add architecture ppc64le Xenial to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: perl
 
+arch:
+ - amd64
+ - ppc64le
+
 sudo: required
-dist: trusty    # includes pandoc 1.12.2.1
+dist: Xenial    # includes pandoc 1.12.2.1
 
 perl:
   - "5.26"


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch and updated Dist to Xenial

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/Pandoc-Elements
Please have a look.

Thank you
